### PR TITLE
Fixed when input is English string will crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ function formatName (arr) {
 }
 
 function processString (str, system) {
+  if (!str) {
+    throw new Error('Input contains non-Chinese characters');
+  }
   // romanization system
   str = romanizationSys[removeDiacritics(str).toUpperCase()][system]
 


### PR DESCRIPTION
When input is English string will crash

```
> var romanize = require('romanize-names')
undefined
> romanize('hello')
TypeError: Cannot read property 'replace' of undefined
    at removeDiacritics (/Users/john/Repository/temp/node_modules/romanize-names/node_modules/diacritics/index.js:310:13)
    at processString (/Users/john/Repository/temp/node_modules/romanize-names/index.js:40:25)
    at /Users/john/Repository/temp/node_modules/romanize-names/index.js:19:12
    at Array.map (native)
    at module.exports (/Users/john/Repository/temp/node_modules/romanize-names/index.js:12:22)
    at repl:1:1
    at REPLServer.defaultEval (repl.js:132:27)
    at bound (domain.js:254:14)
    at REPLServer.runBound [as eval] (domain.js:267:12)
    at REPLServer.<anonymous> (repl.js:279:12)
```

The `TypeError`is from node package `diacritics` https://github.com/andrewrk/node-diacritics/blob/master/index.js#L310
